### PR TITLE
Implement Document wrapper format

### DIFF
--- a/pkg/models/feed_test.go
+++ b/pkg/models/feed_test.go
@@ -1,16 +1,12 @@
 package models_test
 
 import (
-	"encoding/json"
-	"encoding/xml"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/rolieup/golie/pkg/models"
+	"github.com/rolieup/golie/pkg/rolie_source"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,20 +19,14 @@ func TestCompareXMLandJSON(t *testing.T) {
 		name := strings.TrimSuffix(base, filepath.Ext(base))
 
 		fmt.Printf("Testing parsing of %s... ", name)
-		xmlReader, err := os.Open(xmlFile)
+		xmlDoc, err := rolie_source.ReadDocumentFromFile(xmlFile)
 		assert.Nil(t, err)
-		xmlParsed := &models.Feed{}
-		decoder := xml.NewDecoder(xmlReader)
-		assert.Nil(t, decoder.Decode(xmlParsed))
 
 		jsonFile := fmt.Sprintf("../../examples/rolie/feed/%s.json", name)
-		jsonParsedRoot := &models.JSONFeedRoot{}
-		jsonBytes, err := ioutil.ReadFile(jsonFile)
+		jsonDoc, err := rolie_source.ReadDocumentFromFile(jsonFile)
 		assert.Nil(t, err)
 
-		assert.Nil(t, json.Unmarshal(jsonBytes, jsonParsedRoot))
-		jsonParsed := &jsonParsedRoot.Feed
-		jsonParsed.XMLName = xmlParsed.XMLName // Disregard that json parser did not populate XMLName
-		assert.Equal(t, xmlParsed, jsonParsed, "XML parser returns different data than json equivalent")
+		jsonDoc.Feed.XMLName = xmlDoc.Feed.XMLName // Disregard that json parser did not populate XMLName
+		assert.Equal(t, xmlDoc, jsonDoc, "XML parser returns different data than json equivalent")
 	}
 }

--- a/pkg/rolie_source/document.go
+++ b/pkg/rolie_source/document.go
@@ -1,0 +1,74 @@
+package rolie_source
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/rolieup/golie/pkg/models"
+)
+
+const (
+	feedRootElement = "feed"
+	// TODO Entry, Service, ...
+)
+
+// Rolie Document. Either Feed, Entry or Service
+type Document struct {
+	XMLName xml.Name `json:"-"`
+	*models.Feed
+}
+
+func ReadDocument(r io.Reader) (*Document, error) {
+	rawBytes, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	d := xml.NewDecoder(bytes.NewReader(rawBytes))
+	for {
+		token, err := d.Token()
+		if err != nil || token == nil {
+			break
+		}
+		switch startElement := token.(type) {
+		case xml.StartElement:
+			switch startElement.Name.Local {
+			case feedRootElement:
+				var feed models.Feed
+				if err := d.DecodeElement(&feed, &startElement); err != nil {
+					return nil, err
+				}
+				return &Document{Feed: &feed}, nil
+			}
+		}
+	}
+
+	var jsonTemp map[string]json.RawMessage
+	if err := json.Unmarshal(rawBytes, &jsonTemp); err == nil {
+		for k, v := range jsonTemp {
+			switch k {
+			case feedRootElement:
+				var feed models.Feed
+				if err := json.Unmarshal(v, &feed); err != nil {
+					return nil, err
+				}
+				return &Document{Feed: &feed}, nil
+			}
+		}
+	}
+
+	return nil, errors.New("Malformed rolie document. Must be XML or JSON.")
+}
+
+func ReadDocumentFromFile(path string) (*Document, error) {
+	reader, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	return ReadDocument(reader)
+}


### PR DESCRIPTION
It will ease all the re-occurring operations wrt marshaling/unmarshaling.

This time it only implements `Feed`. Will add more once I add tests for the other documents.