### PR TITLE
Golie info should support remote resources transparently

### DIFF
--- a/cmd/golie/info/info.go
+++ b/cmd/golie/info/info.go
@@ -2,8 +2,6 @@ package info
 
 import (
 	"errors"
-	"fmt"
-	"os"
 
 	"github.com/rolieup/golie/pkg/rolie"
 	"github.com/spf13/cobra"
@@ -14,15 +12,7 @@ var Cmd = &cobra.Command{
 	Short: "Print summary information about given ROLIE resource",
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
-			return errors.New("Please provide path to your pre-existing ROLIE file as command-line argument")
-		}
-		path := args[0]
-		stat, err := os.Stat(path)
-		if err != nil {
-			return fmt.Errorf("Could not stat '%s': %v", path, err)
-		}
-		if stat.IsDir() {
-			return fmt.Errorf("Provided path '%s' does not point to a file but to a directory", path)
+			return errors.New("Please provide path or URL to your pre-existing ROLIE file as command-line argument")
 		}
 		return nil
 	},

--- a/pkg/rolie/info.go
+++ b/pkg/rolie/info.go
@@ -5,8 +5,8 @@ import (
 	"github.com/rolieup/golie/pkg/rolie_source"
 )
 
-func Info(path string) error {
-	document, err := rolie_source.ReadDocumentFromFile(path)
+func Info(uri string) error {
+	document, err := rolie_source.ReadDocumentFromURI(uri)
 	if err != nil {
 		return fmt.Errorf("Failed to parse rolie document %s", err)
 	}

--- a/pkg/rolie/info.go
+++ b/pkg/rolie/info.go
@@ -25,6 +25,9 @@ func Info(uri string) error {
 			entries = "entry"
 		}
 		fmt.Printf("Contains %d %s.\n", len(feed.Entry), entries)
+		for _, e := range feed.Entry {
+			fmt.Printf("\t- %s (%s)\n", e.Title, e.ID)
+		}
 	} else if document.Service != nil {
 		fmt.Println("Document Type: ROLIE Service")
 		service := document.Service

--- a/pkg/rolie_source/document.go
+++ b/pkg/rolie_source/document.go
@@ -8,8 +8,10 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/rolieup/golie/pkg/models"
+	"github.com/rolieup/golie/pkg/utils"
 )
 
 const (
@@ -98,6 +100,19 @@ func ReadDocumentFromFile(path string) (*Document, error) {
 		return nil, err
 	}
 	return ReadDocument(reader)
+}
+
+func ReadDocumentFromURI(uri string) (*Document, error) {
+	if strings.HasPrefix(uri, "http://") || strings.HasPrefix(uri, "https://") {
+		readCloser, err := utils.Acquire(uri)
+		if err != nil {
+			return nil, err
+		}
+		defer readCloser.Close()
+		return ReadDocument(readCloser)
+	} else {
+		return ReadDocumentFromFile(uri)
+	}
 }
 
 // Writes both json and xml files. Provide path without extension.

--- a/pkg/utils/acquire.go
+++ b/pkg/utils/acquire.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+
+	"github.com/rolieup/golie/version"
+	log "github.com/sirupsen/logrus"
+)
+
+func Acquire(URI string) (io.ReadCloser, error) {
+	log.Infof("Downloading %s\n", URI)
+
+	client := &http.Client{}
+	// Make a request
+	req, err := http.NewRequest("GET", URI, nil)
+	if err != nil {
+		return nil, err
+	}
+	// Send GolieVersion in Header
+	useragent := fmt.Sprintf("Golie/%s (%s/%s)", version.Version, runtime.GOOS, runtime.GOARCH)
+	req.Header.Add("User-Agent", useragent)
+	req.Header.Set("Accept", "application/json")
+	response, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode != 200 {
+		return nil, fmt.Errorf("Unexpected response %d from server on %s", response.StatusCode, URI)
+	}
+	return response.Body, nil
+}


### PR DESCRIPTION
```
golie info https://atopathways.redhatgov.io/compliance-as-code/scap/feed.json
```