### PR TITLE
Ability to filter content by `golie clone`

### DIFF
--- a/cmd/golie/clone/clone.go
+++ b/cmd/golie/clone/clone.go
@@ -22,10 +22,15 @@ var Cmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return rolie.Clone(args[0], dir)
+		filter, err := cmd.Flags().GetString("filter")
+		if err != nil {
+			return err
+		}
+		return rolie.Clone(args[0], dir, filter)
 	},
 }
 
 func init() {
 	Cmd.Flags().String("dir", "./", "Directory to clone the feed into.")
+	Cmd.Flags().String("filter", "", "Filter downloaded files. Accepts regex that matches on rolie properties")
 }


### PR DESCRIPTION
```
golie clone --debug --filter rhel8 --dir ./my_content https://atopathways.redhatgov.io/compliance-as-code/scap/feed.json
DEBUG Running client in DEBUG mode                 
INFO Downloading https://atopathways.redhatgov.io/compliance-as-code/scap/feed.json 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-firefox-cpe-dictionary.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-firefox-cpe-oval.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-firefox-ds-1.2.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-firefox-ds.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-firefox-ocil.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-firefox-oval.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-firefox-xccdf.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-jre-cpe-dictionary.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-jre-cpe-oval.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-jre-ds-1.2.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-jre-ds.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-jre-ocil.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-jre-oval.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-jre-xccdf.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-ocp3-cpe-dictionary.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-ocp3-cpe-oval.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-ocp3-ds-1.2.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-ocp3-ds.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-ocp3-ocil.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-ocp3-oval.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-ocp3-xccdf.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-ocp4-cpe-dictionary.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-ocp4-cpe-oval.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-ocp4-ds-1.2.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-ocp4-ds.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-ocp4-ocil.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-ocp4-oval.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-ocp4-xccdf.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhcos4-cpe-dictionary.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhcos4-cpe-oval.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhcos4-ds-1.2.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhcos4-ds.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhcos4-ocil.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhcos4-oval.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhcos4-xccdf.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel6-cpe-dictionary.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel6-cpe-oval.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel6-ds-1.2.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel6-ds.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel6-ocil.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel6-oval.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel6-xccdf.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel7-cpe-dictionary.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel7-cpe-oval.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel7-ds-1.2.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel7-ds.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel7-ocil.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel7-oval.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel7-xccdf.xml 
INFO Downloading https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel8-cpe-dictionary.xml 
INFO Downloading https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel8-cpe-oval.xml 
INFO Downloading https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel8-ds-1.2.xml 
INFO Downloading https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel8-ds.xml 
INFO Downloading https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel8-ocil.xml 
INFO Downloading https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel8-oval.xml 
INFO Downloading https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel8-xccdf.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhosp13-cpe-dictionary.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhosp13-cpe-oval.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhosp13-ds-1.2.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhosp13-ds.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhosp13-ocil.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhosp13-oval.xml 
DEBUG Skipping (filtered out) download of https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhosp13-xccdf.xml 
```